### PR TITLE
Make issues more usable and manageable

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Context and related problem
+<!--- Is your feature request related to a problem? Please describe. -->
+<!--- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe the solution you would like**
-A clear and concise description of what you want to happen.
+## Description of the feature
+<!--- Describe the solution you would like -->
+<!--- A clear and concise description of what you want to happen. -->
 
-*If applicable, describe alternatives you've considered*
-A clear and concise description of any alternative solutions or features you've considered.
-
-*If applicable, provide additional context*
-Add any other context or screenshots about the feature request here.
+## Acceptable alternatives
+<!--- If applicable, describe alternatives you've considered -->
+<!--- A clear and concise description of any alternative solutions or features you've considered. -->

--- a/.github/ISSUE_TEMPLATE/user_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/user_bug_report.md
@@ -14,10 +14,13 @@ assignees: ''
 
 ## Current Behavior
 <!--- Tell us what happens instead of the expected behavior -->
+<!--- Don't hesitate to link screenshots to help us with -->
+<!--- understanding your situation. -->
 
 ## Steps to Reproduce
 <!--- Provide a link to a live example, or an unambiguous set of steps to -->
 <!--- reproduce this bug. -->
+
 ## Context (Environment)
 <!--- How has this issue affected you? What are you trying to accomplish? -->
 <!--- Providing context helps us come up with a solution that is most -->

--- a/.github/ISSUE_TEMPLATE/user_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/user_bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a bug you encountered in Graasp
+title: '🐛 Bug report'
+labels: bug
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. -->
+## Context (Environment)
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most -->
+<!--- useful in the real world. Include as many detail as possible, such as -->
+<!--- your browser informations, your OS, and other details. In that -->
+<!--- context, too much information isn't a thing. -->
+
+## Workaround
+<!--- IF APPLICABLE, tell us how you dealt with this bug -->

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Graasp Feedback
 
-This repository captures [feature requests](./.github/ISSUE_TEMPLATE/feature_request.md), [bug reports](./.github/ISSUE_TEMPLATE/user_bug_report.md), and user feedback from across the Graasp ecosystem.
+This repository captures [💡 feature requests](./.github/ISSUE_TEMPLATE/feature_request.md), [🐛 bug reports](./.github/ISSUE_TEMPLATE/user_bug_report.md), and user feedback from across the Graasp ecosystem.
 
-## I am a Graasp user.
+## For Graasp users
 
 ### I encountered a problem. How should I report this problem?
 
@@ -14,7 +14,11 @@ If you need a new feature, or have a great idea, please, [fill a feature request
 
 ---
 
-## I am a Graasp developer.
+## For Graasp developers 
+
+### 📚 Documentation
+
+Documentation for Graasp is available on [graasp.github.io/docs/](https://graasp.github.io/docs/).
 
 ### Management of the issues
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,29 @@
 # Graasp Feedback
 
-This repository captures feature requests, bug reports, and user feedback from across the Graasp ecosystem.
+This repository captures [feature requests](./.github/ISSUE_TEMPLATE/feature_request.md), [bug reports](./.github/ISSUE_TEMPLATE/user_bug_report.md), and user feedback from across the Graasp ecosystem.
 
+## I am a Graasp user.
+
+### I encountered a problem. How should I report this problem?
+
+If you encountered a problem in Graasp, it would be very helpful to us if you could [fill an issue](https://github.com/graasp/graasp-feedback/issues/new?assignees=&labels=🐛%20bug&template=user_bug_report.md&title=).
+
+### I have a need or an idea. How can I ask for a new feature?
+
+If you need a new feature, or have a great idea, please, [fill a feature request](https://github.com/graasp/graasp-feedback/issues/new?assignees=&labels=💡%20feature&template=feature_request.md&title=).
+
+---
+
+## I am a Graasp developer.
+
+### Management of the issues
+
+The issues of this repository is used to track feature requests and bug report from Graasp's users. To help with their management, issues should be labeled.
+
+| Label groups | Labels    |
+|--------------|-----------|
+| Type         | ![documentation](https://img.shields.io/github/labels/graasp/graasp-feedback/📚%20documentation?style=flat-square) ![feature](https://img.shields.io/github/labels/graasp/graasp-feedback/💡%20feature?style=flat-square) ![bug](https://img.shields.io/github/labels/graasp/graasp-feedback/🐛%20bug?style=flat-square) |
+| Platform     | ![backend](https://img.shields.io/github/labels/graasp/graasp-feedback/🏭%20backend?style=flat-square) ![mobile](https://img.shields.io/github/labels/graasp/graasp-feedback/📱%20mobile?style=flat-square) ![web](https://img.shields.io/github/labels/graasp/graasp-feedback/🕸️%20web?style=flat-square)   |
+| Context       | ![player](https://img.shields.io/github/labels/graasp/graasp-feedback/player?style=flat-square) ![library](https://img.shields.io/github/labels/graasp/graasp-feedback/library?style=flat-square) ![builder](https://img.shields.io/github/labels/graasp/graasp-feedback/builder?style=flat-square) ![analytics](https://img.shields.io/github/labels/graasp/graasp-feedback/analytics?style=flat-square) ![application](https://img.shields.io/github/labels/graasp/graasp-feedback/application?style=flat-square) |
+| State         | ![needs triage](https://img.shields.io/github/labels/graasp/graasp-feedback/🔀%20needs%20triage?style=flat-square) ![on hold](https://img.shields.io/github/labels/graasp/graasp-feedback/✋%20on%20hold?style=flat-square) ![in progress](https://img.shields.io/github/labels/graasp/graasp-feedback/🔨%20in%20progress?style=flat-square) ![needs information](https://img.shields.io/github/labels/graasp/graasp-feedback/❓%20needs%20information?style=flat-square) |
+| Inactive      | ![invalid](https://img.shields.io/github/labels/graasp/graasp-feedback/invalid?style=flat-square) ![wontfix](https://img.shields.io/github/labels/graasp/graasp-feedback/wontfix?style=flat-square) ![duplicate](https://img.shields.io/github/labels/graasp/graasp-feedback/duplicate?style=flat-square) |


### PR DESCRIPTION
I updated the README, the labels and the issue templates with the hope that we can centralize the input from end users in this repo. This repository should be an intermediate between user feedback (oral, emails, or even directly here) and the issues of the relevant repository.

The README is very simple at the moment. Please, share you thoughts and suggestions on how to improve it. The same goes for the templates and the labels.